### PR TITLE
refactor/syntax - syntax improvements

### DIFF
--- a/src/Interpreter.ts
+++ b/src/Interpreter.ts
@@ -170,7 +170,7 @@ export class Interpreter implements ExprVisitor<PlumberObject>, StmtVisitor<void
   }
 
   stringify(object: PlumberObject): string {
-    if (object === null) return 'nil'
+    if (object === null) return 'null'
 
     if (typeof object === 'number') {
       let text = object.toString()

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -165,7 +165,7 @@ export class Parser {
     const name = this.consume(TokenType.Identifier, 'Expect class name.')
 
     let superclass: VariableExpr | null = null
-    if (this.match(TokenType.Less)) {
+    if (this.match(TokenType.Extends)) {
       this.consume(TokenType.Identifier, 'Expect superclass name.')
       superclass = new VariableExpr(this.previous())
     }

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -55,7 +55,7 @@ import { SyntaxError } from './errors/error'
  * - declaration -> classDecl | funDecl | varDecl | statement ;
  * - classDecl -> "class" IDENTIFIER ( "<" IDENTIFIER )? "{" function* "}" ;
  * - funDecl -> "fun" function ;
- * - varDecl -> "var" IDENTIFIER ( "=" expression )? ";" ;
+ * - letDecl -> "let" IDENTIFIER ( "=" expression )? ";" ;
  * 
  * STATEMENTS
  * The remaining statement rules produce side effects, but do not introduce bindings.
@@ -157,7 +157,7 @@ export class Parser {
   private declaration(): Stmt {
     if (this.match(TokenType.Class)) return this.classDeclaration()
     if (this.match(TokenType.Fun)) return this.funDeclaration('function')
-    if (this.match(TokenType.Var)) return this.varDeclaration()
+    if (this.match(TokenType.Let)) return this.letDeclaration()
     return this.statement()
   }
 
@@ -198,8 +198,8 @@ export class Parser {
     let initializer
     if (this.match(TokenType.Semicolon)) {
       initializer = null
-    } else if (this.match(TokenType.Var)) {
-      initializer = this.varDeclaration()
+    } else if (this.match(TokenType.Let)) {
+      initializer = this.letDeclaration()
     } else {
       initializer = this.expressionStatement()
     }
@@ -264,7 +264,7 @@ export class Parser {
     return new ReturnStmt(keyword, value)
   }
 
-  private varDeclaration(): Stmt {
+  private letDeclaration(): Stmt {
     const name: Token = this.consume(
       TokenType.Identifier,
       'Expect variable name.',
@@ -557,7 +557,7 @@ export class Parser {
         case TokenType.If:
         case TokenType.Print:
         case TokenType.Return:
-        case TokenType.Var:
+        case TokenType.Let:
         case TokenType.While:
           return
       }

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -54,7 +54,7 @@ import { SyntaxError } from './errors/error'
  * 
  * - declaration -> classDecl | funDecl | varDecl | statement ;
  * - classDecl -> "class" IDENTIFIER ( "<" IDENTIFIER )? "{" function* "}" ;
- * - funDecl -> "fun" function ;
+ * - funDecl -> "function" function ;
  * - letDecl -> "let" IDENTIFIER ( "=" expression )? ";" ;
  * 
  * STATEMENTS
@@ -156,7 +156,7 @@ export class Parser {
 
   private declaration(): Stmt {
     if (this.match(TokenType.Class)) return this.classDeclaration()
-    if (this.match(TokenType.Fun)) return this.funDeclaration('function')
+    if (this.match(TokenType.Function)) return this.functionDeclaration('function')
     if (this.match(TokenType.Let)) return this.letDeclaration()
     return this.statement()
   }
@@ -174,7 +174,7 @@ export class Parser {
 
     const methods: Array<FunctionStmt> = []
     while (!this.check(TokenType.RightBrace) && !this.isAtEnd()) {
-      methods.push(this.funDeclaration('method'))
+      methods.push(this.functionDeclaration('method'))
     }
 
     this.consume(TokenType.RightBrace, "Expect '}' after class body.")
@@ -294,7 +294,7 @@ export class Parser {
     return new ExpressionStmt(expr)
   }
 
-  private funDeclaration(kind: string): FunctionStmt {
+  private functionDeclaration(kind: string): FunctionStmt {
     const name = this.consume(TokenType.Identifier, `Expect ${kind} name.`)
     this.consume(TokenType.LeftParen, `Expect '(' after ${kind} name.`)
     const parameters: Array<Token> = []
@@ -553,7 +553,7 @@ export class Parser {
       switch (this.peek().type) {
         case TokenType.Class:
         case TokenType.For:
-        case TokenType.Fun:
+        case TokenType.Function:
         case TokenType.If:
         case TokenType.Print:
         case TokenType.Return:

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -86,7 +86,7 @@ import { SyntaxError } from './errors/error'
  * 
  * - unary -> ( "!" | "-" ) unary | call ;
  * - call -> primary ( "(" arguments? ")" | "." IDENTIFIER)* ;
- * - primary -> NUMBER | STRING | "true" | "false" | "nil" | "(" expression ")" | IDENTIFIER | "super" "." IDENTIFIER ;
+ * - primary -> NUMBER | STRING | "true" | "false" | "null" | "(" expression ")" | IDENTIFIER | "super" "." IDENTIFIER ;
  * 
  * UTILITY RULES
  * In order to keep the above rules a little cleaner, some of the grammar is split
@@ -474,7 +474,7 @@ export class Parser {
   private primary(): Expr {
     if (this.match(TokenType.False)) return new LiteralExpr(false)
     if (this.match(TokenType.True)) return new LiteralExpr(true)
-    if (this.match(TokenType.Nil)) return new LiteralExpr(null)
+    if (this.match(TokenType.Null)) return new LiteralExpr(null)
 
     if (this.match(TokenType.Number, TokenType.String))
       return new LiteralExpr(this.previous().literal)

--- a/src/Scanner.ts
+++ b/src/Scanner.ts
@@ -18,7 +18,7 @@ const keywords: Record<string, TokenType> = {
   super: TokenType.Super,
   this: TokenType.This,
   true: TokenType.True,
-  var: TokenType.Var,
+  let: TokenType.Let,
   while: TokenType.While,
 }
 

--- a/src/Scanner.ts
+++ b/src/Scanner.ts
@@ -11,7 +11,7 @@ const keywords: Record<string, TokenType> = {
   for: TokenType.For,
   fun: TokenType.Fun,
   if: TokenType.If,
-  nil: TokenType.Nil,
+  null: TokenType.Null,
   or: TokenType.Or,
   print: TokenType.Print,
   return: TokenType.Return,

--- a/src/Scanner.ts
+++ b/src/Scanner.ts
@@ -7,6 +7,7 @@ const keywords: Record<string, TokenType> = {
   and: TokenType.And,
   class: TokenType.Class,
   else: TokenType.Else,
+  extends: TokenType.Extends,
   false: TokenType.False,
   for: TokenType.For,
   function: TokenType.Function,

--- a/src/Scanner.ts
+++ b/src/Scanner.ts
@@ -9,7 +9,7 @@ const keywords: Record<string, TokenType> = {
   else: TokenType.Else,
   false: TokenType.False,
   for: TokenType.For,
-  fun: TokenType.Fun,
+  function: TokenType.Function,
   if: TokenType.If,
   null: TokenType.Null,
   or: TokenType.Or,

--- a/src/ast/TokenType.ts
+++ b/src/ast/TokenType.ts
@@ -35,7 +35,7 @@ export enum TokenType {
   Fun = 'Fun',
   For = 'For',
   If = 'If',
-  Nil = 'Nil',
+  Null = 'Null',
   Or = 'Or',
   Print = 'Print',
   Return = 'Return',

--- a/src/ast/TokenType.ts
+++ b/src/ast/TokenType.ts
@@ -32,7 +32,7 @@ export enum TokenType {
   Class = 'Class',
   Else = 'Else',
   False = 'False',
-  Fun = 'Fun',
+  Function = 'Function',
   For = 'For',
   If = 'If',
   Null = 'Null',

--- a/src/ast/TokenType.ts
+++ b/src/ast/TokenType.ts
@@ -31,6 +31,7 @@ export enum TokenType {
   And = 'And',
   Class = 'Class',
   Else = 'Else',
+  Extends = 'Extends',
   False = 'False',
   Function = 'Function',
   For = 'For',

--- a/src/ast/TokenType.ts
+++ b/src/ast/TokenType.ts
@@ -42,7 +42,7 @@ export enum TokenType {
   Super = 'Super',
   This = 'This',
   True = 'True',
-  Var = 'Var',
+  Let = 'Let',
   While = 'While',
 
   EOF = 'EOF',


### PR DESCRIPTION
Partially addresses #3 

This PR implements the following syntax improvements:

## Global functions
- ABS(num) - calculates the absolute value of the function
- POWER(base, exponent) - calculates and returns the power of the base to the exponent

## Syntax improvements
- convert `var` to `let`, more closely resembling what officers are used to
- convert `nil` to `null`
- convert `fun` to `function`
- convert `<` to `extends` for inheritance

## Codebase naming
- Convert codebase references to the previous language "Lox" to "Plumber", since this repository is called PlumberScript