### PR TITLE
Fix: Cannot import package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,19 +2,24 @@
   "name": "@opengovsg/plumberscript",
   "description": "Programming language for Plumber Compute, implemented in TypeScript",
   "author": "Yuanruo Liang <yuanruo@open.gov.sg>",
-  "main": "./dist/index.js",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/opengovsg/PlumberScript"
   },
-  "bin": {},
+  "version": "0.0.1",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "dev": "ts-node-script ./src/main.ts",
     "lint": "eslint",
     "test": "vitest",
-    "plumber": "node ./dist/main.js"
+    "plumber": "node ./dist/main.js",
+    "prepublish": "npm run build"
   },
   "devDependencies": {
     "@types/node": "^20.11.5",
@@ -25,6 +30,5 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3",
     "vitest": "^1.3.1"
-  },
-  "version": "0.0.1"
+  }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,8 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["**/*.test.ts"]
+  "exclude": ["./src/**/*.test.ts"],
+  "compilerOptions": {
+    "declaration": true,
+    "removeComments": true
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -106,4 +106,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */,
   },
+  "include": ["./src/**/*.ts"],
 }


### PR DESCRIPTION
## Problem
Users cannot import PlumberScript because it's is currently packaged as a pure TS package, but the `main` property in `package.json` is pointing at a js file in `dist`.

## Solution
Re-configure PlumberScript as a JS package with TS declarations.

I _think_ it's possible to keep this as a pure TS package, but I'm not a fan of this approach. This requires our users to turn on TS transpilation for `node_modules`, which:
- Is not common behaviour
- Will either slow down TS compilation time for projects with giant `node_modules`, or make management unwieldy (have to explicitly include our `node_modules` folder in their `tsconfig.json`)

## Tests
- Check with `npm link` that importing this works correctly.

## Deploy Notes
- Will need to bump version number before this can be published.