### PR TITLE
fix: build before publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint",
     "test": "vitest",
     "plumber": "node ./dist/main.js",
-    "prepublishOnly": "npm run build"
+    "prepack": "npm run build"
   },
   "devDependencies": {
     "@types/node": "^20.11.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint",
     "test": "vitest",
     "plumber": "node ./dist/main.js",
-    "prepublish": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@types/node": "^20.11.5",


### PR DESCRIPTION
The previous `prepublish` command was deprecated and no longer runs before `npm publish` is executed.