### PR TITLE
feat/arity - refactor to allow for variable number of arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint",
     "test": "vitest",
     "plumber": "node ./dist/main.js",
-    "prepublish": "npm run build"
+    "prepack": "npm run build"
   },
   "devDependencies": {
     "@types/node": "^20.11.5",

--- a/src/Interpreter.ts
+++ b/src/Interpreter.ts
@@ -382,9 +382,9 @@ export class Interpreter
       throw new RuntimeError('Can only call functions and classes', expr.paren)
     }
 
-    if (args.length !== callee.arity()) {
+    if (!callee.arity(args.length)) {
       throw new RuntimeError(
-        `Expected ${callee.arity()} arguments but got ${args.length}.`,
+        `Incorrect number of arguments provided: ${args.length}.`,
         expr.paren,
       )
     }

--- a/src/__tests__/class.test.ts
+++ b/src/__tests__/class.test.ts
@@ -1,0 +1,69 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { PlumberScript } from '../PlumberScript'
+import { beforeEach } from 'node:test'
+
+const plumber = new PlumberScript()
+
+describe('Class', () => {
+    beforeAll(() => {
+        plumber.evaluate(`
+            class Person {
+                init(first, last) {
+                    this.first = first;
+                    this.last = last;
+                }
+
+                fullName() {
+                    return this.first + " " + this.last;
+                }
+
+                setFirst(first) {
+                    this.first = first;
+                }
+
+                setLast(last) {
+                    this.last = last;
+                }
+            }
+        `)
+
+        plumber.evaluate(`
+            class Employee extends Person {
+                init(first, last, age) {
+                    super.init(first, last);
+                    this.age = age;
+                }
+
+                isRetirementAge() {
+                    return this.age >= 65;
+                }
+            }
+        `)
+    })
+    it('allows for methods in the base class to work correctly', () => {
+        let fullName = plumber.evaluate(`
+            let p = Person("John","Doe");
+            p.fullName()
+        `)
+        expect(fullName).toEqual('John Doe')
+
+        fullName = plumber.evaluate(`p.setFirst("Jane"); p.fullName()`)
+        expect(fullName).toEqual('Jane Doe')
+
+        fullName = plumber.evaluate(`p.first = "John"; p.fullName()`)
+        expect(fullName).toEqual('John Doe')
+  })
+
+    it('allows for methods in the superclass to work correctly', () => {
+        plumber.evaluate(`
+            let e = Employee("Chu Kang","Phua",65);
+        `)
+
+        let fullName = plumber.evaluate(`e.fullName()`) // test superclass method
+        expect(fullName).toEqual('Chu Kang Phua')
+        
+        let isRetirementAge = plumber.evaluate(`e.isRetirementAge()`)
+        expect(isRetirementAge).toEqual(true)
+    })
+})

--- a/src/ast/PlumberClass.ts
+++ b/src/ast/PlumberClass.ts
@@ -40,9 +40,9 @@ export class PlumberClass extends PlumberCallable {
     return instance
   }
 
-  arity(): number {
+  arity(argLength: number): boolean {
     const initializer = this.findMethod('init')
-    if (initializer === null) return 0
-    return initializer.arity()
+    if (initializer === null) return true
+    return initializer.arity(argLength)
   }
 }

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -4,7 +4,7 @@ import { PlumberInstance } from './PlumberInstance'
 import { FunctionStmt } from './Stmt'
 
 export abstract class PlumberCallable {
-  abstract arity(): number
+  abstract arity(argLength: number): boolean
   abstract call(interpreter: Interpreter, args: Array<PlumberObject>): PlumberObject
 }
 
@@ -34,8 +34,8 @@ export class PlumberFunction extends PlumberCallable {
     return `<fn ${this.declaration.name.lexeme}>`
   }
 
-  arity(): number {
-    return this.declaration.params.length
+  arity(argLength: number): boolean {
+    return argLength === this.declaration.params.length
   }
 
   call(interpreter: Interpreter, args: Array<PlumberObject>): PlumberObject {

--- a/src/lib/abs.ts
+++ b/src/lib/abs.ts
@@ -2,8 +2,8 @@ import { Interpreter } from '../Interpreter'
 import { PlumberCallable, PlumberObject } from '../ast/types'
 
 export class AbsFunction extends PlumberCallable {
-  arity(): number {
-    return 1
+  arity(argLength: number): boolean {
+    return argLength === 1
   }
 
   call(_: Interpreter, args: Array<PlumberObject>): PlumberObject {

--- a/src/lib/power.ts
+++ b/src/lib/power.ts
@@ -2,8 +2,8 @@ import { Interpreter } from '../Interpreter'
 import { PlumberCallable, PlumberObject } from '../ast/types'
 
 export class PowerFunction extends PlumberCallable {
-  arity(): number {
-    return 2
+  arity(argLength: number): boolean {
+    return argLength === 2
   }
 
   call(_: Interpreter, args: Array<PlumberObject>): PlumberObject {

--- a/src/lib/str-replace-all.ts
+++ b/src/lib/str-replace-all.ts
@@ -2,8 +2,8 @@ import { Interpreter } from '../Interpreter'
 import { PlumberCallable, PlumberObject } from '../ast/types'
 
 export class StrReplaceAllFunction extends PlumberCallable {
-  arity(): number {
-    return 3
+  arity(argLength: number): boolean {
+    return argLength === 3
   }
 
   call(_: Interpreter, args: Array<PlumberObject>): PlumberObject {


### PR DESCRIPTION
## Problem

Currently, the number of arguments of a function or method is fixed, as the AST is inflexible about the number of arguments that can be accepted in a function call.

This inhibits further language development as sometimes we would prefer to have an optional number of arguments.

For example,  in https://github.com/opengovsg/PlumberScript/pull/10 we do not have the option of providing the function `UNIDECODE(string, [code_point_start, code_point_end])`, as the number of arguments would have to be fixed as either 1 or 3, but not both,.

## Solution

Move the valid arguments check into `PlumberCallable`'s `arity` function, by refactoring it's type signature to `arity(argsLength: number): boolean`.

## Tests

As we already have tests for global functions, this PR extends the coverage to include methods and inheritance, so as to ensure that no functionality has been broken.